### PR TITLE
fix IMU time lag

### DIFF
--- a/phidgets_imu/src/imu_ros_i.cpp
+++ b/phidgets_imu/src/imu_ros_i.cpp
@@ -109,17 +109,17 @@ void ImuRosI::calibrate()
 void ImuRosI::processImuData(CPhidgetSpatial_SpatialEventDataHandle* data, int i)
 {
   // **** calculate time from timestamp
-
-  //ros::Time time_now = ros::Time::now();
-
   ros::Duration time_imu(data[i]->timestamp.seconds + 
                          data[i]->timestamp.microseconds * 1e-6);
 
   ros::Time time_now = time_zero_ + time_imu;
 
   double timediff = time_now.toSec() - ros::Time::now().toSec();
-  if (fabs(timediff) > 0.1)
-    ROS_WARN("IMU time lags behind by %f seconds!", timediff);
+  if (fabs(timediff) > 0.1) {
+    ROS_WARN("IMU time lags behind by %f seconds, resetting IMU time offset!", timediff);
+    time_zero_ = ros::Time::now() - time_imu;
+    time_now = ros::Time::now();
+  }
 
   // **** initialize if needed
 


### PR DESCRIPTION
On our IMU (Phidgets Spatial 1044), the time reported by the IMU often
lags behind significantly (somewhere between 3 and 90 seconds). The lag
is (more or less) constant. The reason seems to be that `phidgets_imu`
assumes that the `zero()` function resets the IMU time, but it only
resets the Gyros.

This pull request checks whether the time difference exceeds a threshold
(hard coded to 0.1 seconds here), and if yes, resets the time offset
again. During my tests, this always happens exactly once (when the first
IMU message arrives); after that, all following messages are in sync.
