### PR TITLE
add some hints to error message

### DIFF
--- a/phidgets_imu/src/imu_ros_i.cpp
+++ b/phidgets_imu/src/imu_ros_i.cpp
@@ -75,7 +75,7 @@ void ImuRosI::initDevice()
 	{
 	  const char *err;
 		CPhidget_getErrorDescription(result, &err);
-		ROS_FATAL("Problem waiting for IMU attachment: %s", err);
+		ROS_FATAL("Problem waiting for IMU attachment: %s Make sure the USB cable is connected and you have executed the phidgets_c_api/setup-udev.sh script.", err);
 	}
 
 	// set the data rate for the spatial events


### PR DESCRIPTION
I just spent 30 minutes trying to figure out why the IMU works on one 
computer and doesn't on another one. Felt a little foolish when I found out
that the udev rules weren't installed; maybe providing some more info in the
error message helps others.
