### PR TITLE
phidgets_api: add libusb dependency

### DIFF
--- a/phidgets_api/package.xml
+++ b/phidgets_api/package.xml
@@ -18,4 +18,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>libusb-1.0-dev</build_depend>
+
+  <run_depend>libusb-1.0</run_depend>
+
 </package>


### PR DESCRIPTION
This caused Jenkins CI tests to fail.
