### PR TITLE
add boost depends to CMakeLists

### DIFF
--- a/phidgets_imu/CMakeLists.txt
+++ b/phidgets_imu/CMakeLists.txt
@@ -1,15 +1,18 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(phidgets_imu)
 
-find_package(catkin REQUIRED COMPONENTS geometry_msgs nodelet phidgets_api roscpp sensor_msgs std_msgs std_srvs tf)
+find_package(catkin REQUIRED COMPONENTS geometry_msgs nodelet pluginlib phidgets_api roscpp sensor_msgs std_msgs std_srvs tf)
+
+find_package(Boost REQUIRED COMPONENTS thread)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES phidgets_imu 
-  CATKIN_DEPENDS geometry_msgs nodelet phidgets_api roscpp sensor_msgs std_msgs std_srvs tf
+  DEPENDS Boost
+  CATKIN_DEPENDS geometry_msgs nodelet pluginlib phidgets_api roscpp sensor_msgs std_msgs std_srvs tf
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 add_library(phidgets_imu src/imu_ros_i.cpp)
 add_library(phidgets_imu_nodelet src/phidgets_imu_nodelet.cpp)
@@ -18,7 +21,7 @@ add_executable(phidgets_imu_node src/phidgets_imu_node.cpp)
 
 add_dependencies(phidgets_imu phidgets_api)
 
-target_link_libraries(phidgets_imu ${catkin_LIBRARIES})
+target_link_libraries(phidgets_imu ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 target_link_libraries(phidgets_imu_nodelet ${catkin_LIBRARIES} phidgets_imu)
 target_link_libraries(phidgets_imu_node ${catkin_LIBRARIES} phidgets_imu)
 

--- a/phidgets_imu/package.xml
+++ b/phidgets_imu/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>nodelet</build_depend>
+  <build_depend>pluginlib</build_depend>
   <build_depend>phidgets_api</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -24,6 +25,7 @@
   <build_depend>tf</build_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>nodelet</run_depend>
+  <run_depend>pluginlib</run_depend>
   <run_depend>phidgets_api</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>


### PR DESCRIPTION
All non-catkin things that we expose in our headers should be added to the
DEPENDS, so that packages which depend on our package will also automatically
link against it.

Also see:
http://answers.ros.org/question/58498/what-is-the-purpose-of-catkin_depends/\#58593
