### PR TITLE
set orientation_covariance[0] to -1

### DIFF
--- a/phidgets_imu/src/imu_ros_i.cpp
+++ b/phidgets_imu/src/imu_ros_i.cpp
@@ -76,6 +76,9 @@ ImuRosI::ImuRosI(ros::NodeHandle nh, ros::NodeHandle nh_private):
     }
   }
 
+  // signal that we have no orientation estimate (see Imu.msg)
+  imu_msg_.orientation_covariance[0] = -1;
+
   initDevice();
 
   if (has_compass_params)


### PR DESCRIPTION
from Imu.msg:

> If you have no estimate for one of the data elements (e.g. your IMU doesn't
produce an orientation
> estimate), please set element 0 of the associated covariance matrix to -1.